### PR TITLE
Fix/handle small quotas

### DIFF
--- a/src/peergos/payment/Builder.java
+++ b/src/peergos/payment/Builder.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 public class Builder {
 
     protected static final long GIGABYTE = 1024*1024*1024L;
+    protected static final long MEGABYTE = 1024*1024L;
 
     public static Supplier<Connection> buildEphemeralSqlite() {
         try {

--- a/src/peergos/payment/PaymentState.java
+++ b/src/peergos/payment/PaymentState.java
@@ -123,6 +123,11 @@ public class PaymentState {
             }
             // take a payment
             Natural remaining = toPay;
+            if (remaining.val == 0 && desiredQuotaBytes.val <= 1024*1024) {
+                userStates.setCurrentQuota(username, desiredQuotaBytes);
+                userStates.setQuotaExpiry(username, now.plusMonths(1));
+                return true;
+            }
             Natural toCharge = minPaymentCents.max(remaining);
             try {
                 CustomerResult customer = userStates.getCustomer(username);

--- a/src/peergos/payment/Server.java
+++ b/src/peergos/payment/Server.java
@@ -120,6 +120,15 @@ public class Server {
         process.start();
     }
 
+    private static long parseQuota(String in) {
+        in = in.trim();
+        if (in.endsWith("g"))
+            return Long.parseLong(in.substring(0, in.length() - 1)) * Builder.GIGABYTE;
+        if (in.endsWith("m"))
+            return Long.parseLong(in.substring(0, in.length() - 1)) * Builder.MEGABYTE;
+        return Long.parseLong(in);
+    }
+
     public static void main(String[] args) throws Exception {
         Main.initCrypto();
         Args a = Args.parse(args);
@@ -130,9 +139,8 @@ public class Server {
         Natural minPayment = new Natural(a.getLong("min-payment", 500));
         Natural defaultFreeQuota = new Natural(a.getLong("free-quota", 100 * 1024*1024L));
         int maxUsers = a.getInt("max-users");
-        Set<Natural> allowedQuotas = Arrays.stream(a.getArg("allowed-quotas", "0,10,100").split(","))
-                .map(Long::parseLong)
-                .map(g -> g * Builder.GIGABYTE)
+        Set<Natural> allowedQuotas = Arrays.stream(a.getArg("allowed-quotas", "0,1m,50g").split(","))
+                .map(Server::parseQuota)
                 .map(Natural::of)
                 .collect(Collectors.toSet());
 

--- a/src/peergos/payment/tests/PaymentStateTests.java
+++ b/src/peergos/payment/tests/PaymentStateTests.java
@@ -10,10 +10,11 @@ import java.util.stream.*;
 
 public class PaymentStateTests {
 
+    private static final long MEGABYTE = 1024*1024L;
     private static final long GIGABYTE = 1024*1024*1024L;
     private static final long POUND = 100;
-    private static final Natural freeQuota = new Natural(100 * 1024 * 1204);
-    private static final Set<Natural> allowedQuotas = Stream.of(0L, 5*GIGABYTE, 7*GIGABYTE, 10*GIGABYTE)
+    private static final Natural freeQuota = new Natural(200 * 1024 * 1024);
+    private static final Set<Natural> allowedQuotas = Stream.of(0L, 1*MEGABYTE, 5*GIGABYTE, 7*GIGABYTE, 10*GIGABYTE, 50*GIGABYTE)
             .map(Natural::of)
             .collect(Collectors.toSet());
 
@@ -257,6 +258,30 @@ public class PaymentStateTests {
         Assert.assertTrue("First payment is for 10GiB", payments.get(0).amount.equals(pricer.convertBytesToCents(desiredQuota)));
         Assert.assertTrue("Second payment is for 7GiB", payments.get(1).amount.equals(pricer.convertBytesToCents(decreasedQuota)));
 
+    }
+
+    @Test
+    public void deletedAccountIsNotChargedFurther() {
+        Natural bytesPerCent = new Natural(GIGABYTE / 10);
+        LinearPricer pricer = new LinearPricer(bytesPerCent);
+        AcceptAll bank = new AcceptAll();
+        PaymentState global = buildPaymentState(bank, pricer);
+        String username = "bob";
+        Natural desiredQuota = new Natural(50 * GIGABYTE);
+        LocalDateTime now = LocalDateTime.now();
+        global.ensureUser(username, now);
+        global.setDesiredQuota(username, desiredQuota, now);
+        long quota = global.getCurrentQuota(username);
+        Assert.assertTrue("Correct quota", quota == desiredQuota.val + freeQuota.val);
+        // simulate deleting account which sets quota to 1 MiB
+        Natural decreasedQuota = new Natural(1 * MEGABYTE);
+        global.setDesiredQuota(username, decreasedQuota, now);
+        global.processAll(now.plusMonths(1));
+        long newQuota = global.getCurrentQuota(username);
+        Assert.assertTrue("Quota decreased", newQuota == decreasedQuota.val + freeQuota.val);
+        List<PaymentResult> payments = bank.getPayments();
+        Assert.assertTrue("Correct number of payments ", payments.size() == 1);
+        Assert.assertTrue("First payment is for 10GiB", payments.get(0).amount.equals(pricer.convertBytesToCents(desiredQuota)));
     }
 
     private static final String example_payment_response = "{\n" +

--- a/src/peergos/payment/tests/PaymentStateTests.java
+++ b/src/peergos/payment/tests/PaymentStateTests.java
@@ -281,7 +281,7 @@ public class PaymentStateTests {
         Assert.assertTrue("Quota decreased", newQuota == decreasedQuota.val + freeQuota.val);
         List<PaymentResult> payments = bank.getPayments();
         Assert.assertTrue("Correct number of payments ", payments.size() == 1);
-        Assert.assertTrue("First payment is for 10GiB", payments.get(0).amount.equals(pricer.convertBytesToCents(desiredQuota)));
+        Assert.assertTrue("First payment is correct", payments.get(0).amount.equals(pricer.convertBytesToCents(desiredQuota)));
     }
 
     private static final String example_payment_response = "{\n" +


### PR DESCRIPTION
Allow small quotas to function correctly.

Use case is deleting an account sets the desired quota to 1 MiB. 

Add a unit test for this case to ensure that deleted accounts are no longer charged. 